### PR TITLE
Hard code artifact group and kind

### DIFF
--- a/utils/index.go
+++ b/utils/index.go
@@ -2,13 +2,13 @@ package utils
 
 import (
 	"fmt"
+	artifactv1 "github.com/openfluxcd/artifact/api/v1alpha1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func OwnerReferenceIndex() func(o ctrlclient.Object) []string {
 	return func(o ctrlclient.Object) []string {
-		gvk := o.GetObjectKind().GroupVersionKind()
-		keys := []string{fmt.Sprintf("%s/%s/%s/%s", gvk.Group, gvk.Kind, o.GetNamespace(), o.GetName())}
+		keys := []string{fmt.Sprintf("%s/%s/%s/%s", artifactv1.GroupVersion.Group, artifactv1.ArtifactKind, o.GetNamespace(), o.GetName())}
 		for _, ref := range o.GetOwnerReferences() {
 			keys = append(keys, fmt.Sprintf("%s/%s/%s/%s", ExtractGroupName(ref.APIVersion), ref.Kind, o.GetNamespace(), ref.Name))
 		}


### PR DESCRIPTION
Since decoding clears the apiversion and kind information (https://github.com/kubernetes/kubernetes/issues/80609), the index does not work consistently.